### PR TITLE
minor bugfix: Add padding to long infoboard titles so that the first and last letters will not be obscured by the gradients

### DIFF
--- a/src/views/InfoboardView.vue
+++ b/src/views/InfoboardView.vue
@@ -3,7 +3,13 @@
     <div v-if="showBody" class="infoboard-container" ref="infoboardContainer">
       <img class="background-image":src="getBackgroundImage()" />
       &nbsp;
-      <div class="title" ref="title"><div class="title-gradient left"></div><div class="titleInner" ref="titleInner">{{ item.title.toUpperCase() }}</div><div class="title-gradient right"></div></div>
+      <div class="title" ref="title">
+        <div class="title-gradient left"></div>
+        <div class="titleInner" ref="titleInner">
+          <span class="title-padding">&nbsp;</span>{{ item.title.toUpperCase() }}<span class="title-padding">&nbsp;</span>
+        </div>
+        <div class="title-gradient right"></div>
+      </div>
       <div class="body" v-if="item.metadata?.vote_results">
         <div v-html="item.body" class="vote-results-body"></div>
         <div class="vote-results">
@@ -132,12 +138,15 @@ $orbitron: 'Orbitron', sans-serif;
     overflow: hidden;
   }
   .titleInner {
-    position: absolute;
     min-width: 100%;
     text-align: center;
     white-space: nowrap;
     position: relative;
     animation: titlescroll 10s linear;
+  }
+  .title-padding {
+    display: inline-block;
+    width: 3rem;
   }
   .title-gradient {
     width: 3rem;


### PR DESCRIPTION
This fixes a minor visual glitch I noticed during run 1: When the title is long enough to need scrolling, the first letter starts out under the left fade-out gradient and the last letter is still under the right gradient when the title stops scrolling. Thus, both of these letters never become fully visible. Adding 3 rem of padding (to match the width of the gradients) on either side of the title fixes this.

(FWIW, a plain CSS `.titleInner { padding: 3rem 0 }` is enough to fix the left side, but apparently not the right side. Rather than fight the CSS box model and figure out how to make it do what I want, I just used explicit padding `<span>`s instead.) 